### PR TITLE
Traduction de `auth-routes.md`

### DIFF
--- a/en/examples/auth-routes.md
+++ b/en/examples/auth-routes.md
@@ -1,5 +1,5 @@
 ---
-title: Authentification de routes (EN)
+title: Authentification de routes
 description: Exemple d'authentification de routes avec Nuxt.js
 github: auth-routes
 livedemo: https://nuxt-auth-routes.gomix.me
@@ -10,11 +10,7 @@ liveedit: https://gomix.com/#!/project/nuxt-auth-routes
 
 > Nuxt.js peut être utilisé pour créer facilement des routes authentifiées.
 
-## Module officiel `auth-module` (EN)
-
-If you want to implement complex authentication flows, for example OAuth2, we suggest using the official [`auth-module`](https://github.com/nuxt-community/auth-module)
-
-## Avec Express et Sessions
+## Module officiel `auth-module`
 
 Si vous souhaitez implémenter un flux d'authentification complexe, par exemple OAuth2, nous suggérons d'utiliser le module officiel [`auth-module`](https://github.com/nuxt-community/auth-module)
 
@@ -226,5 +222,3 @@ export default {
 ```
 
 Nous pouvons voir dans la méthode `fetch` que nous appelons `redirect('/')` lorsque notre utilisateur n'est pas connecté.
-
-<p style="width: 294px;position: fixed; top : 64px; right: 4px;" class="Alert Alert--orange"><strong>⚠Cette page est actuellement en cours de traduction française. Vous pouvez repasser plus tard ou <a href="https://github.com/vuejs-fr/nuxt" target="_blank">participer à la traduction</a> de celle-ci dès maintenant !</strong></p>


### PR DESCRIPTION
Bonjour !
J'ai juste supprimé la partie concernant **auth-module** en anglais qui était déjà traduite en français mais qui avait un mauvais titre ( "Avec Express et Sessions" ). Peux être une erreur lors d'un merge ?

Je vais sans doute pouvoir aider sur quelques autres traductions si vous le souhaitez :)